### PR TITLE
Use previous commit of supervised-installer script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ sh <(curl -sSL https://get.docker.com) &>/dev/null
 
 # Install Home Assistant
 msg "Installing Home Assistant..."
-bash <(curl -sL https://github.com/home-assistant/supervised-installer/raw/master/installer.sh) &>/dev/null
+bash <(curl -sL https://raw.githubusercontent.com/home-assistant/supervised-installer/c674830d8ddc6af9d618755a7995af939dd73fde/installer.sh) &>/dev/null
 
 # Fix for Home Assistant Supervisor btime check
 HA_PATH=$(jq --raw-output '.data' /etc/hassio.json)


### PR DESCRIPTION
It appears the Home Assistant Supervised (also known as Home Assistant on Generic Linux) installation method is no longer supported - [maybe](https://www.home-assistant.io/blog/2020/05/09/deprecating-home-assistant-supervised-on-generic-linux/)...? There has been an additional confirmation step added to the install script that causes the installation to hang. This instead uses a previous version of the script to bypass the confirmation.