### PR TITLE
Update to proxmox 7, ignore release changes

### DIFF
--- a/create_container.sh
+++ b/create_container.sh
@@ -78,13 +78,13 @@ wget -qO - ${REPO}/tarball/master | tar -xz --strip-components=1
 # Modify LXC permissions to support Docker
 LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
 cat <<EOF >> $LXC_CONFIG
-lxc.cgroup.devices.allow: a
+lxc.cgroup2.devices.allow: a
 lxc.cap.drop:
 EOF
 
 # Load modules for Docker before starting LXC
 cat << 'EOF' >> $LXC_CONFIG
-lxc.hook.pre-start: sh -ec 'for module in aufs overlay; do modinfo $module; $(lsmod | grep -Fq $module) || modprobe $module; done;'
+lxc.hook.pre-start: sh -ec 'for module in overlay; do modinfo $module; $(lsmod | grep -Fq $module) || modprobe $module; done;'
 EOF
 
 # Set autodev hook to enable access to devices in container
@@ -110,7 +110,7 @@ lxc-cmd apt-get -y purge openssh-{client,server} >/dev/null
 
 # Update container OS
 msg "Updating container OS..."
-lxc-cmd apt-get update >/dev/null
+lxc-cmd apt-get update --allow-releaseinfo-change >/dev/null
 lxc-cmd apt-get -qqy upgrade &>/dev/null
 
 # Install prerequisites


### PR DESCRIPTION
Applied patch from https://forum.proxmox.com/threads/home-assistant-lxc-script-error-on-proxmox-7.92377/post-402845 to work with Proxmox 7

Also added --allow-releasechange-info to ignore the following error:
```
Setting up container OS...
Updating container OS...
E: Repository 'http://security.debian.org buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://ftp.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
E: Repository 'http://ftp.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
```

> --allow-releaseinfo-change
Allow the update command to continue downloading data from a repository which changed its information of the release contained in the repository indicating e.g a new major release. APT will fail at the update command for such repositories until the change is confirmed to ensure the user is prepared for the change. See also apt-secure(8) for details on the concept and configuration. 